### PR TITLE
bijiben: remove webkitgtk override

### DIFF
--- a/pkgs/desktops/gnome-3/3.24/default.nix
+++ b/pkgs/desktops/gnome-3/3.24/default.nix
@@ -255,10 +255,7 @@ let
 
   accerciser = callPackage ./apps/accerciser { };
 
-  bijiben = callPackage ./apps/bijiben {
-    # https://bugzilla.gnome.org/show_bug.cgi?id=728293
-    webkitgtk = pkgs.webkitgtk24x-gtk3;
-  };
+  bijiben = callPackage ./apps/bijiben { };
 
   cheese = callPackage ./apps/cheese { };
 


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=728293 is marked fixed in the
bug tracker and a release was made after the fix was committed.