### PR TITLE
gnome-disks: fix missing schemas for gnome-disk-image-mounter

### DIFF
--- a/pkgs/desktops/gnome-3/3.24/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/3.24/core/gnome-disk-utility/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, pkgconfig, udisks2, libsecret, libdvdread
-, bash, gtk3, glib, makeWrapper, cracklib, libnotify
-, itstool, gnome3, librsvg, gdk_pixbuf, libxml2, python
+, bash, gtk3, glib, wrapGAppsHook, cracklib, libnotify
+, itstool, gnome3, gdk_pixbuf, libxml2, python
 , libcanberra_gtk3, libxslt, libtool, docbook_xsl, libpwquality }:
 
 stdenv.mkDerivation rec {
@@ -16,14 +16,8 @@ stdenv.mkDerivation rec {
                   libxslt libtool libsecret libpwquality cracklib
                   libnotify libdvdread libcanberra_gtk3 docbook_xsl
                   gdk_pixbuf gnome3.defaultIconTheme
-                  librsvg udisks2 gnome3.gnome_settings_daemon
-                  gnome3.gsettings_desktop_schemas makeWrapper libxml2 ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/gnome-disks" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
+                  udisks2 gnome3.gnome_settings_daemon
+                  gnome3.gsettings_desktop_schemas wrapGAppsHook libxml2 ];
 
   meta = with stdenv.lib; {
     homepage = https://en.wikipedia.org/wiki/GNOME_Disks;


### PR DESCRIPTION
###### Motivation for this change
Fixes gnome-disk-image-mounter

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

